### PR TITLE
Post-Release 3.0.0 merge to 'develop'

### DIFF
--- a/TDS.ItemRenderer/pom.xml
+++ b/TDS.ItemRenderer/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.opentestsystem.delivery</groupId>
 		<artifactId>item-renderer-master</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0</version>
 	</parent>
 
 	<name>tds-itemRenderer</name>

--- a/TDS.ItemRenderer/pom.xml
+++ b/TDS.ItemRenderer/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.opentestsystem.delivery</groupId>
 		<artifactId>item-renderer-master</artifactId>
-		<version>3.0.0</version>
+		<version>3.0.1-SNAPSHOT</version>
 	</parent>
 
 	<name>tds-itemRenderer</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>item-renderer-master</artifactId>
   <packaging>pom</packaging>
   <name>item-renderer-master</name>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0</version>
 
   <parent>
     <groupId>org.opentestsystem.shared</groupId>
@@ -47,7 +47,7 @@
     <connection>scm:git:https://github.com/SmarterApp/TDS_ItemRenderer.git</connection>
     <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ItemRenderer.git</developerConnection>
     <url>https://github.com/SmarterApp/TDS_ItemRenderer</url>
-    <tag>HEAD</tag>
+    <tag>3.0.0</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>item-renderer-master</artifactId>
   <packaging>pom</packaging>
   <name>item-renderer-master</name>
-  <version>3.0.0</version>
+  <version>3.0.1-SNAPSHOT</version>
 
   <parent>
     <groupId>org.opentestsystem.shared</groupId>
@@ -47,7 +47,7 @@
     <connection>scm:git:https://github.com/SmarterApp/TDS_ItemRenderer.git</connection>
     <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ItemRenderer.git</developerConnection>
     <url>https://github.com/SmarterApp/TDS_ItemRenderer</url>
-    <tag>3.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -18,11 +18,18 @@
     <module>resource-bundler</module>
   </modules>
 
-  <properties>
-
-  </properties>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>${maven-source-plugin.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
         <artifactId>maven-release-plugin</artifactId>

--- a/resource-bundler/pom.xml
+++ b/resource-bundler/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.opentestsystem.delivery</groupId>
 		<artifactId>item-renderer-master</artifactId>
-		<version>3.0.0</version>
+		<version>3.0.1-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/resource-bundler/pom.xml
+++ b/resource-bundler/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>resource-bundler</artifactId>
 	<packaging>jar</packaging>
@@ -9,7 +8,7 @@
 	<parent>
 		<groupId>org.opentestsystem.delivery</groupId>
 		<artifactId>item-renderer-master</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0</version>
 	</parent>
 
 	<properties>

--- a/shared-blackbox/pom.xml
+++ b/shared-blackbox/pom.xml
@@ -8,6 +8,6 @@
 	<parent>
 		<groupId>org.opentestsystem.delivery</groupId>
 		<artifactId>item-renderer-master</artifactId>
-		<version>3.0.0</version>
+		<version>3.0.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/shared-blackbox/pom.xml
+++ b/shared-blackbox/pom.xml
@@ -8,6 +8,6 @@
 	<parent>
 		<groupId>org.opentestsystem.delivery</groupId>
 		<artifactId>item-renderer-master</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0</version>
 	</parent>
 </project>


### PR DESCRIPTION
I will not merge to 'develop' until all dependent projects have been updated to reference the released version 3.0.0