### PR TITLE
remove fix focus api call

### DIFF
--- a/item-renderer-web/src/main/webapp/Scripts/Shells/loginshell.js
+++ b/item-renderer-web/src/main/webapp/Scripts/Shells/loginshell.js
@@ -676,12 +676,6 @@ LoginShell.saveBrowserInfo = function () {
 };
 
 LoginShell.Events.subscribe('onInit', function () {
-
-    // Windows and Linux SB have an issue where you cannot type into text areas without this hack.
-    if (Util.Browser.isSecure() && !Util.Browser.isMac()) {
-        Util.SecureBrowser.fixFocus();
-    }
-
     // set SB preferences
     if (Util.Browser.isSecure()) {
         setTimeout(LoginShell.setMozillaPreferences, 0);

--- a/item-renderer-web/src/main/webapp/Scripts/Tools/tds_ToolManager.js
+++ b/item-renderer-web/src/main/webapp/Scripts/Tools/tds_ToolManager.js
@@ -277,15 +277,6 @@
             }, 0);
         });
 
-        panel.beforeHideEvent.subscribe(function () {
-            // BUG: When selecting text in dialog frame select boxes can't get focused
-            // STEPS: Open help, select text, leave text selected and close help.. no select boxes work (grades or global accs)
-            if (Util.Browser.isSecure() && !Util.Browser.isMac()) {
-                // NOTE: Don't do this on mac or it causes focus bug #30808
-                Util.SecureBrowser.fixFocus();
-            }
-        });
-
         panel.hideEvent.subscribe(function() {
             TM.Events.fire('onHide', panel);
             TDS.ARIA.showContent();


### PR DESCRIPTION
secure browser 10 does not have the "fixFocus" api that was used to workaround an older secure browser ui bug.