### PR TITLE
TDS-1494: Bugfix/xhr err msg translation

### DIFF
--- a/item-renderer-web/src/main/webapp/Scripts/Tools/tds_xhr.js
+++ b/item-renderer-web/src/main/webapp/Scripts/Tools/tds_xhr.js
@@ -37,7 +37,7 @@ TDS.XhrManager = (function(Util) {
 
     YAHOO.extend(TDSXhr, Util.XhrManager);
 
-    TDSXhr.defaultErrorMessage = 'There was a problem with your request.';
+    TDSXhr.defaultErrorMessage = Messages.get('Messages.Label.XHRDefaultError') || 'There was a problem with your request.';
     
     TDSXhr.JsonReply = {
         OK: 0,


### PR DESCRIPTION
This change will remove the hard-coded "there was a problem with your request." text and make it configurable/translatable like many of the other messages in TDS.

This PR is related to/dependent on [this PR in TDS_TestDeliverySystemDataAccess](https://github.com/SmarterApp/TDS_TestDeliverySystemDataAccess/pull/45)