### PR TITLE
Use fully matched voices first, then mismatched if necessary.

### DIFF
--- a/item-renderer-web/src/main/webapp/Scripts/TTS2/config.js
+++ b/item-renderer-web/src/main/webapp/Scripts/TTS2/config.js
@@ -59,6 +59,9 @@ TTS.Config = {
     },
     setVoice: function(val, langs){
       langs = langs || [TTS.Config.Lang.ENU.Code];
+      if(!Array.isArray(langs)) {
+        langs = [langs];
+      }
       for(var k in langs){
         var lang = langs[k];
         TTS.getInstance().setVoice(val, lang);
@@ -195,7 +198,7 @@ TTS.Config = {
     { name: "VW Julie", priority: 1, language: "ENU" },
     { name: "Julie", priority: 1, language: "ENU" },
     { name: "Kate", priority: 1, language: "ENU" },
-    { name: "Paul", priority: 1, language: "ENU" },
+    // { name: "Paul", priority: 1, language: "ENU" },  // Conflicts with Paulina
     { name: "Cepstral_Marta", priority: 1, language: "ESN" },
     { name: "Cepstral_David", priority: 1, language: "ENU" },
     { name: "Cepstral_Miguel", priority: 2, language: "ESN" },


### PR DESCRIPTION
On Mac, the system voice names match what's in the list of known voices, so the substring matching was adding a buggy voice 'eng'. On windows, the only voice that works is found by the old substring matching code (using the string 'eng'). 
So I made it prefer the exact matches and fall back to the substring. Now it works nice everywhere. Also commented out the voice 'Paul' because it substring matched badly with Paulina.
This code really needs to be rewritten to find the voices in a more straightforward way.