### PR TITLE
Hotfix/asl safari fix

### DIFF
--- a/TDS.ItemRenderer/src/main/java/tds/itemrenderer/web/RemoteResourceHandler.java
+++ b/TDS.ItemRenderer/src/main/java/tds/itemrenderer/web/RemoteResourceHandler.java
@@ -13,6 +13,7 @@
 
 package tds.itemrenderer.web;
 
+import AIR.Common.Web.StaticFileHandler3;
 import TDS.Shared.Exceptions.TDSHttpException;
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,7 +22,10 @@ import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 import tds.itemrenderer.repository.ContentRepository;
 
@@ -33,20 +37,42 @@ public class RemoteResourceHandler extends ResourceHandler {
     @Override
     public void init() throws ServletException {
         // This needs to be called to inject our ContentRepository, as this class is instantiated by the servlet, not spring
-        SpringBeanAutowiringSupport.processInjectionBasedOnCurrentContext (this);
+        SpringBeanAutowiringSupport.processInjectionBasedOnCurrentContext(this);
     }
 
     @Override
-    public void staticFileHandler(final HttpServletRequest request, final HttpServletResponse response) throws TDSHttpException, IOException
-    {
+    public void staticFileHandler(final HttpServletRequest request, final HttpServletResponse response) throws TDSHttpException, IOException {
         String physicalPath = overrideExecuteUrlPath(request);
-        byte[] bytes = IOUtils.toByteArray(contentRepository.findResource(physicalPath));
 
-        // In order to display SVG files in an <img> tag, the browser needs to know the content type, where this isn't needed for other types
-        if (physicalPath != null && physicalPath.toLowerCase().endsWith(".svg")) {
-            response.setHeader("Content-Type", "image/svg+xml");
+        if (physicalPath != null && physicalPath.toLowerCase().endsWith(".mp4")) {
+            try {
+                final File resourceFile = stream2file(contentRepository.findResource(physicalPath));
+                StaticFileHandler3.ProcessRequestInternal(request, response, resourceFile.getPath());
+                resourceFile.delete();
+            } catch (Exception e) {
+                throw new IOException(e);
+            }
+        } else {
+            byte[] bytes = IOUtils.toByteArray(contentRepository.findResource(physicalPath));
+            // In order to display SVG files in an <img> tag, the browser needs to know the content type, where this isn't needed for other types
+            if (physicalPath != null && physicalPath.toLowerCase().endsWith(".svg")) {
+                response.setHeader("Content-Type", "image/svg+xml");
+            }
+
+            response.getOutputStream().write(bytes);
         }
 
-        response.getOutputStream().write(bytes);
     }
+
+    private static File stream2file(InputStream in) throws IOException {
+        final File tempFile = File.createTempFile("temp-vid", ".mp4");
+        // This file will be deleted when the application exits as a fall back - but we should still try and delete the file explicitly
+        tempFile.deleteOnExit();
+        try (FileOutputStream out = new FileOutputStream(tempFile)) {
+            IOUtils.copy(in, out);
+        }
+
+        return tempFile;
+    }
+
 }

--- a/TDS.ItemRenderer/src/main/java/tds/itemrenderer/web/RemoteResourceHandler.java
+++ b/TDS.ItemRenderer/src/main/java/tds/itemrenderer/web/RemoteResourceHandler.java
@@ -45,13 +45,9 @@ public class RemoteResourceHandler extends ResourceHandler {
         String physicalPath = overrideExecuteUrlPath(request);
 
         if (physicalPath != null && physicalPath.toLowerCase().endsWith(".mp4")) {
-            try {
-                final File resourceFile = stream2file(contentRepository.findResource(physicalPath));
-                StaticFileHandler3.ProcessRequestInternal(request, response, resourceFile.getPath());
-                resourceFile.delete();
-            } catch (Exception e) {
-                throw new IOException(e);
-            }
+            final File resourceFile = stream2file(contentRepository.findResource(physicalPath));
+            StaticFileHandler3.ProcessRequestInternal(request, response, resourceFile.getPath());
+            resourceFile.delete();
         } else {
             byte[] bytes = IOUtils.toByteArray(contentRepository.findResource(physicalPath));
             // In order to display SVG files in an <img> tag, the browser needs to know the content type, where this isn't needed for other types


### PR DESCRIPTION
For mp4 media files used in ASL, we need to populate various Content HTTP headers in order for playback to work properly in Safari. The lack of these headers was causing Safari on both iOS and macOS to close the connection prematurely.